### PR TITLE
[feat] Button 분리(GotoDetail, GotoApply)

### DIFF
--- a/src/components/Button/GotoApplyButton.tsx
+++ b/src/components/Button/GotoApplyButton.tsx
@@ -1,0 +1,23 @@
+import { BaseButton } from "../../styles/common";
+
+type ApplyButtonType = "apply" | "reserve";
+
+interface GotoApplyButtonProps {
+  type: ApplyButtonType;
+  url?: string;
+}
+
+const buttonTextMap: Record<ApplyButtonType, string> = {
+  apply: "신청하기",
+  reserve: "예약하기",
+};
+
+const GotoApplyButton: React.FC<GotoApplyButtonProps> = ({ type, url }) => {
+  const handleClick = () => {
+    if (url) window.open(url, "_blank");
+  };
+
+  return <BaseButton onClick={handleClick}>{buttonTextMap[type]}</BaseButton>;
+};
+
+export default GotoApplyButton;

--- a/src/components/Button/GotoDetailButton.tsx
+++ b/src/components/Button/GotoDetailButton.tsx
@@ -1,0 +1,14 @@
+import { useNavigate } from "react-router-dom";
+import { BaseButton } from "../../styles/common";
+
+interface GotoDetailButtonProps {
+  id: string;
+}
+
+const GotoDetailButton: React.FC = () => {
+  const navigate = useNavigate();
+
+  return <BaseButton onClick={() => navigate("/")}>자세히보기</BaseButton>;
+};
+
+export default GotoDetailButton;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,0 +1,17 @@
+import GotoDetailButton from "./GotoDetailButton";
+import GotoApplyButton from "./GotoApplyButton";
+
+// 타입 정의
+type ActionButtonType = "learnMore" | "apply" | "reserve";
+
+interface ActionButtonProps {
+  type: ActionButtonType;
+  url?: string; // apply/reserve 버튼용
+}
+
+const ActionButton: React.FC<ActionButtonProps> = ({ type, url }) => {
+  if (type === "learnMore") return <GotoDetailButton />;
+  return <GotoApplyButton type={type} url={url} />;
+};
+
+export default ActionButton;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -3,36 +3,14 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import GotoMapButtonSvg from "../assets/buttons/GotoMapButton.svg";
-import EducationDummyImage from "../assets/dummyImage/EducationDummyImage.svg";
 import UnBookmarkIcon from "../assets/icons/UnBookmarkIcon.svg";
 import BookmarkIcon from "../assets/icons/BookmarkIcon.svg";
 import CardTag from "./CardTag";
 import EducationTextSection from "./EducationTextSection";
 import { ApiEduResponse, ApiSpaceResponse } from "../types/responses";
 import SpaceTextSection from "./SpaceTextSection";
-
-// ActionButton 타입 정의
-type ActionButtonType = "learnMore" | "apply";
-
-// ActionButton 컴포넌트: 자세히 보기/신청하기 버튼
-interface ActionButtonProps {
-  text?: string;
-  type: ActionButtonType;
-  onClick?: () => void;
-}
-const ActionButton: React.FC<ActionButtonProps> = ({ text, type, onClick }) => {
-  const isLearnMore = type === "learnMore";
-  return (
-    <StyledActionButton
-      type="button"
-      aria-label={isLearnMore ? "자세히 보기" : text}
-      onClick={onClick}
-      $buttonType={type}
-    >
-      {isLearnMore ? "자세히 보기" : text}
-    </StyledActionButton>
-  );
-};
+import GotoDetailButton from "./Button/GotoDetailButton";
+import GotoApplyButton from "./Button/GotoApplyButton";
 
 interface CardProps<T = "space" | "education"> {
   type: T;
@@ -51,20 +29,6 @@ const Card: React.FC<CardProps> = ({ type, data }) => {
       return !prev;
     });
   };
-
-  // 자세히 보기 버튼 클릭 핸들러
-  const handleLearnMore = () => {
-    alert("자세히 보기 클릭!");
-  };
-
-  // 신청하기 버튼 클릭 핸들러
-  const handleApply = () => {
-    alert("신청하기 클릭!");
-  };
-
-  useEffect(() => {
-    console.log(data);
-  }, [data]);
 
   return (
     <CardOuter>
@@ -118,11 +82,14 @@ const Card: React.FC<CardProps> = ({ type, data }) => {
             <IconButton type="button" aria-label="지도보기">
               <img src={GotoMapButtonSvg} alt="지도보기" />
             </IconButton>
-            <ActionButton type="learnMore" onClick={handleLearnMore} />
-            <ActionButton
-              type="apply"
-              text={type === "education" ? "신청하기" : "예약하기"}
-              onClick={handleApply}
+            <GotoDetailButton />
+            <GotoApplyButton
+              type={type === "education" ? "apply" : "reserve"}
+              url={
+                type === "education"
+                  ? (data as ApiEduResponse).eduUrl
+                  : (data as ApiSpaceResponse).spaceUrl
+              }
             />
           </CardButtonContainer>
         </CardContainer>
@@ -334,39 +301,5 @@ const IconButton = styled.button`
   @media (max-width: 600px) {
     margin-right: 10px;
     flex-shrink: 0;
-  }
-`;
-
-// 자세히 보기/신청하기 버튼
-const StyledActionButton = styled.button<{ $buttonType?: ActionButtonType }>`
-  background: #6287fa;
-  color: #fff;
-  border: none;
-  border-radius: 999px;
-  font-size: 1rem;
-  font-weight: 500;
-  height: 34px;
-  min-width: ${({ $buttonType }) =>
-    $buttonType === "learnMore"
-      ? "120px"
-      : $buttonType === "apply"
-      ? "120px"
-      : "90px"};
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s, transform 0.1s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  &:active {
-    transform: scale(0.97);
-  }
-
-  @media (max-width: 600px) {
-    min-width: 0;
-    flex: 1;
-    font-size: 0.98rem;
-    padding: 0 8px;
-    height: 32px;
-    gap: 20px;
   }
 `;

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -63,6 +63,34 @@ export const Button = styled.button<{
   }}
 `;
 
+export const BaseButton = styled.button`
+  background: ${colors.primary};
+  color: ${colors.white};
+  border: none;
+  border-radius: 50px;
+  font-size: 1rem;
+  font-weight: 500;
+  height: 34px;
+  min-width: 120px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, transform 0.1s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  &:active {
+    transform: scale(0.97);
+  }
+
+  @media (max-width: 600px) {
+    min-width: 0;
+    flex: 1;
+    font-size: 0.98rem;
+    padding: 0 8px;
+    height: 32px;
+    gap: 20px;
+  }
+`;
+
 export const Card = styled.div`
   background-color: ${colors.white};
   border-radius: 8px;


### PR DESCRIPTION
- button type 3개 정의 : apply, reserve는 url로 외부 페이지 이동, learnMore은 상세보기 페이지로 이동하지만 현재는 /로 이동
- Card에서 button 컴포넌트 제거
- common.ts에 button 기본 스타일 설정
- Button/index.tsx는 아직 사용하지는 않음

**Check List :memo:**

- [x] Pull Request 제목 : [유형] 변경 사항 요약
- [x] 설명 & 이슈 번호 작성

**설명 (필수)**

이 PR에서 어떤 변경을 했는지 상세히 설명해주세요.
관련된 Issue 번호를 포함하세요.

1. #30 

2. 변경 사항
- button type 3개 정의 : apply, reserve는 url로 외부 페이지 이동, learnMore은 상세보기 페이지로 이동하지만 현재는 /로 이동
- Card에서 button 컴포넌트 제거
- common.ts에 button 기본 스타일 설정
- Button/index.tsx는 아직 사용하지는 않음

3. 스크린샷 (선택)
 

<br>

---

**review 참고 사항 (선택)**

추가로 알릴 내용이 있다면 여기에 작성해주세요.

1. 각 버튼마다 넘겨주는 props가 다르니 확인 필요
